### PR TITLE
Count vacation hours not days + readonly vacation hours for users who are not admins

### DIFF
--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -116,7 +116,7 @@ class UserProfileSubscriber implements EventSubscriberInterface
             })
           }
 
-          window.addEventListener('load', showVacationInformation);
+          document.addEventListener('DOMContentLoaded', showVacationInformation);
           </script>";
         }
 

--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -96,12 +96,7 @@ class UserProfileSubscriber implements EventSubscriberInterface
                 'Extra Vacation Hours': " . $event->getUser()->getPreferenceValue('extra-vacation-hours') . ",
             };
 
-            let form;
-            while(!form) {
-              await new Promise(resolve => setTimeout(resolve, 10));
-              form = document.querySelector('form');
-            }
-
+            const form = document.querySelector('form');
             const formBody = form.querySelector('.card-body');
 
             Object.entries(window.DS_VacationData).forEach(([preferenceLabel, preferenceValue]) => {
@@ -121,7 +116,7 @@ class UserProfileSubscriber implements EventSubscriberInterface
             })
           }
 
-          showVacationInformation();
+          window.addEventListener('load', showVacationInformation);
           </script>";
         }
 

--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -85,8 +85,11 @@ class UserProfileSubscriber implements EventSubscriberInterface
           // if user is not admin, we show them an unsubmittable fake input, so they know their vacation information
           echo "<script>
           async function showVacationInformation() {
-            // for some reason this script is included twice in the page, so we break if its already loaded
-            if (window.DS_VacationData) return;
+            if (window.DS_VacationData) {
+              // The `loadUserProfile` is usually called multiple times,
+              // and we need to bail out if this function is executed once.
+              return;
+            }
 
             window.DS_VacationData = {
                 'Target Weekly Hours': " . $event->getUser()->getPreferenceValue('target-weekly-hours') . ",

--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -162,15 +162,5 @@ class UserProfileSubscriber implements EventSubscriberInterface
         $worked_hours = $this->repository->getStatistic('duration', $startDate, $endDate, $user) / 60 / 60;
 
         $work_left = $expected_work_hours - $total_vacation_hours - $worked_hours;
-        print_r([
-            'fte_ratio' => $fte_ratio,
-            'leftover_hours' => $leftover_hours,
-            'vacation_hours_per_second' => $vacation_hours_per_second,
-            'earned_hours' => $earned_hours,
-            'expected_work_hours' => $expected_work_hours,
-            'worked_hours' => $worked_hours,
-            'work_left' => $work_left,
-            'extra_vacation_hours' => $extra_vacation_hours
-        ]);
     }
 }

--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -6,6 +6,7 @@ use App\Entity\UserPreference;
 use App\Event\UserPreferenceEvent;
 use App\Event\PrepareUserEvent;
 use App\Repository\TimesheetRepository;
+use Symfony\Component\Security\Core\Security;
 use DateTime;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
@@ -15,10 +16,12 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 class UserProfileSubscriber implements EventSubscriberInterface
 {
     protected $repository;
+    private $security;
 
-    public function __construct(TimesheetRepository $repository)
+    public function __construct(TimesheetRepository $repository, Security $security)
     {
         $this->repository = $repository;
+        $this->security = $security;
     }
 
     public static function getSubscribedEvents(): array
@@ -35,27 +38,29 @@ class UserProfileSubscriber implements EventSubscriberInterface
             return;
         }
 
+        // Check if the user has the ROLE_ADMIN role
+        if (!$this->security->isGranted('ROLE_ADMIN')) {
+            return; // Only allow admins to customize preferences
+        }
+
+        // Preferences for admins
         $event->addPreference(
             (new UserPreference('target-weekly-hours', 32))
-                // ->setName('target-weekly-hours')
                 ->setValue(32)
                 ->setType(IntegerType::class)
         );
         $event->addPreference(
             (new UserPreference('target-weekly-start', '1970-01-30'))
-                // ->setName('target-weekly-start')
                 ->setValue('1970-01-30')
                 ->setType(TextType::class)
         );
         $event->addPreference(
             (new UserPreference('yearly-fte-vacation-days', 35))
-                // ->setName('yearly-fte-vacation-days')
                 ->setValue(35)
                 ->setType(NumberType::class)
         );
         $event->addPreference(
             (new UserPreference('start-of-period-vacation-hours', 0))
-                // ->setName('start-of-period-vacation-hours')
                 ->setValue(0)
                 ->setType(NumberType::class)
         );
@@ -68,18 +73,19 @@ class UserProfileSubscriber implements EventSubscriberInterface
         }
 
         $accounting_start = strtotime($user->getPreferenceValue('target-weekly-start'));
-        if ($accounting_start === false)
+        if ($accounting_start === false) {
             return;
+        }
         $startDate = new DateTime();
         $startDate->setTimestamp($accounting_start);
 
         $seconds_elapsed = time() - $accounting_start;
-        if ($seconds_elapsed < 0)
+        if ($seconds_elapsed < 0) {
             return;
+        }
         $endDate = new DateTime();
 
         $fte_ratio = $user->getPreferenceValue('target-weekly-hours', 0) / 40.0;
-
         $leftover_hours = $user->getPreferenceValue('start-of-period-vacation-hours', 0);
 
         // Not accounting for leap years
@@ -87,14 +93,12 @@ class UserProfileSubscriber implements EventSubscriberInterface
         $vacation_hours_per_second = 24 * $user->getPreferenceValue('yearly-fte-vacation-days') / $year_length;
 
         $earned_hours = $fte_ratio * $seconds_elapsed * $vacation_hours_per_second;
-
         $total_vacation_hours = $leftover_hours + $earned_hours;
 
         $week_length = 7 * 24 * 60 * 60;
         $elapsed_weeks = $seconds_elapsed / $week_length;
 
         $expected_work_hours = $elapsed_weeks * $fte_ratio * 40;
-
         $worked_hours = $this->repository->getStatistic('duration', $startDate, $endDate, $user) / 60 / 60;
 
         $work_left = $expected_work_hours - $total_vacation_hours - $worked_hours;

--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -148,7 +148,6 @@ class UserProfileSubscriber implements EventSubscriberInterface
         // Not accounting for leap years
         $year_length = 365 * 24 * 60 * 60;
         $vacation_hours_per_second = 24 * $user->getPreferenceValue('yearly-vacation-hours') / $year_length;
-        $vacation_hours_per_week = $user->getPreferenceValue('yearly-vacation-hours') * $fte_ratio;
 
         $extra_vacation_hours = 5 * $user->getPreferenceValue('extra-vacation-hours');
 

--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -39,30 +39,34 @@ class UserProfileSubscriber implements EventSubscriberInterface
         }
 
         // Check if the user has the ROLE_ADMIN role
-        if (!$this->security->isGranted('ROLE_ADMIN')) {
-            return; // Only allow admins to customize preferences
-        }
+        $isAdmin = $this->security->isGranted('ROLE_ADMIN');
 
-        // Preferences for admins
         $event->addPreference(
             (new UserPreference('target-weekly-hours', 32))
                 ->setValue(32)
                 ->setType(IntegerType::class)
+                ->setOptions(['attr' => ['disabled' => !$isAdmin]]) // Make readonly if not admin
         );
+
         $event->addPreference(
             (new UserPreference('target-weekly-start', '1970-01-30'))
                 ->setValue('1970-01-30')
                 ->setType(TextType::class)
+                ->setOptions(['attr' => ['disabled' => !$isAdmin]]) // Make readonly if not admin
         );
+
         $event->addPreference(
             (new UserPreference('yearly-fte-vacation-days', 35))
                 ->setValue(35)
                 ->setType(NumberType::class)
+                ->setOptions(['attr' => ['disabled' => !$isAdmin]]) // Make readonly if not admin
         );
+
         $event->addPreference(
             (new UserPreference('start-of-period-vacation-hours', 0))
                 ->setValue(0)
                 ->setType(NumberType::class)
+                ->setOptions(['attr' => ['disabled' => !$isAdmin]]) // Make readonly if not admin
         );
     }
 

--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -43,35 +43,31 @@ class UserProfileSubscriber implements EventSubscriberInterface
 
         $event->addPreference(
             (new UserPreference('target-weekly-hours', 32))
-                ->setValue(32)
+                // ->setValue(32)
                 ->setType(IntegerType::class)
                 ->setOptions(['attr' => ['disabled' => !$isAdmin]]) // Make readonly if not admin
         );
 
         $event->addPreference(
             (new UserPreference('target-weekly-start', '1970-01-30'))
-                ->setValue('1970-01-30')
                 ->setType(TextType::class)
                 ->setOptions(['attr' => ['disabled' => !$isAdmin]]) // Make readonly if not admin
         );
 
         $event->addPreference(
             (new UserPreference('yearly-vacation-hours', 168))
-                ->setValue(35)
                 ->setType(NumberType::class)
                 ->setOptions(['attr' => ['disabled' => !$isAdmin]]) // Make readonly if not admin
         );
 
         $event->addPreference(
             (new UserPreference('start-of-period-vacation-hours', 0))
-                ->setValue(0)
                 ->setType(NumberType::class)
                 ->setOptions(['attr' => ['disabled' => !$isAdmin]]) // Make readonly if not admin
         );
 
         $event->addPreference(
-            (new UserPreference('extra-vacation', 0))
-                ->setValue(0)
+            (new UserPreference('extra-vacation-hours', 0))
                 ->setType(IntegerType::class)
                 ->setOptions(['attr' => ['disabled' => !$isAdmin]]) // Make readonly if not admin
         );
@@ -104,7 +100,7 @@ class UserProfileSubscriber implements EventSubscriberInterface
         $vacation_hours_per_second = 24 * $user->getPreferenceValue('yearly-vacation-hours') / $year_length;
         $vacation_hours_per_week = $user->getPreferenceValue('yearly-vacation-hours') * $fte_ratio;
 
-        $extra_vacation_hours = 5 * $user->getPreferenceValue('extra-vacation');
+        $extra_vacation_hours = 5 * $user->getPreferenceValue('extra-vacation-hours');
 
         $earned_hours = $fte_ratio * $seconds_elapsed * $vacation_hours_per_second;
         $total_vacation_hours = $leftover_hours + $earned_hours + $extra_vacation_hours;

--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -147,11 +147,11 @@ class UserProfileSubscriber implements EventSubscriberInterface
 
         // Not accounting for leap years
         $year_length = 365 * 24 * 60 * 60;
-        $vacation_hours_per_second = 24 * $user->getPreferenceValue('yearly-vacation-hours') / $year_length;
+        $vacation_hours_per_second = $user->getPreferenceValue('yearly-vacation-hours') / $year_length;
 
-        $extra_vacation_hours = 5 * $user->getPreferenceValue('extra-vacation-hours');
+        $extra_vacation_hours = $user->getPreferenceValue('extra-vacation-hours');
 
-        $earned_hours = $fte_ratio * $seconds_elapsed * $vacation_hours_per_second;
+        $earned_hours = $seconds_elapsed * $vacation_hours_per_second;
         $total_vacation_hours = $leftover_hours + $earned_hours + $extra_vacation_hours;
 
         $week_length = 7 * 24 * 60 * 60;
@@ -161,5 +161,7 @@ class UserProfileSubscriber implements EventSubscriberInterface
         $worked_hours = $this->repository->getStatistic('duration', $startDate, $endDate, $user) / 60 / 60;
 
         $work_left = $expected_work_hours - $total_vacation_hours - $worked_hours;
+        
+        print_r($work_left);
     }
 }

--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -43,41 +43,88 @@ class UserProfileSubscriber implements EventSubscriberInterface
 
         $event->addPreference(
             (new UserPreference('target-weekly-hours', 32))
-                ->setValue(32)
+                ->setEnabled($isAdmin)
                 ->setType(IntegerType::class)
                 ->setOptions(['label' => 'Target Weekly Hours' . ($isAdmin ? '' : ' (Read-Only)'), 'attr' => ['readonly' => !$isAdmin]]) // Make readonly if not admin
         );
 
         $event->addPreference(
             (new UserPreference('target-weekly-start', '1970-01-30'))
-                ->setValue('1970-01-30')
+                ->setEnabled($isAdmin)
                 ->setType(TextType::class)
                 ->setOptions(['label'    => 'Target Weekly Start Date' . ($isAdmin ? '' : ' (Read-Only)'), 'attr' => ['readonly' => !$isAdmin]]) // Make readonly if not admin
         );
 
         $event->addPreference(
             (new UserPreference('yearly-vacation-hours', 168))
-                ->setValue(35)
+                ->setEnabled($isAdmin)
                 ->setType(NumberType::class)
                 ->setOptions(['label' => 'Yearly Vacation Hours' . ($isAdmin ? '' : ' (Read-Only)'), 'attr' => ['readonly' => !$isAdmin]]) // Make readonly if not admin
         );
 
         $event->addPreference(
             (new UserPreference('start-of-period-vacation-hours', 0))
-                ->setValue(0)
+                ->setEnabled($isAdmin)
                 ->setType(NumberType::class)
                 ->setOptions(['label' => 'Start of Period Vacation Hours' . ($isAdmin ? '' : ' (Read-Only)'), 'attr' => ['readonly' => !$isAdmin]]) // Make readonly if not admin
-            );
+        );
 
         $event->addPreference(
             (new UserPreference('extra-vacation-hours', 0))
+                ->setEnabled($isAdmin)
                 ->setType(IntegerType::class)
-                ->setOptions(['attr' => ['disabled' => !$isAdmin]]) // Make readonly if not admin
+                ->setOptions(['label' => 'Extra Vacation Hours' . ($isAdmin ? '' : ' (Read-Only)'), 'attr' => ['readonly' => !$isAdmin]]) // Make readonly if not admin
         );
     }
 
     public function loadUserProfile(PrepareUserEvent $event)
     {
+        $isAdmin = $this->security->isGranted('ROLE_ADMIN');
+
+        if(!$isAdmin) {
+          // if user is not admin, we show them an unsubmittable fake input, so they know their vacation information
+          echo "<script>
+          async function showVacationInformation() {
+            // for some reason this script is included twice in the page, so we break if its already loaded
+            if (window.DS_VacationData) return;
+
+            window.DS_VacationData = {
+                'Target Weekly Hours': " . $event->getUser()->getPreferenceValue('target-weekly-hours') . ",
+                'Target Weekly Start': " . $event->getUser()->getPreferenceValue('target-weekly-start') . ",
+                'Yearly Vacation Hours': " . $event->getUser()->getPreferenceValue('yearly-vacation-hours') . ",
+                'Start of Period Vacation Hours': " . $event->getUser()->getPreferenceValue('start-of-period-vacation-hours') . ",
+                'Extra Vacation Hours': " . $event->getUser()->getPreferenceValue('extra-vacation-hours') . ",
+            };
+
+            let form;
+            while(!form) {
+              await new Promise(resolve => setTimeout(resolve, 10));
+              form = document.querySelector('form');
+            }
+
+            const formBody = form.querySelector('.card-body');
+
+            Object.entries(window.DS_VacationData).forEach(([preferenceLabel, preferenceValue]) => {
+              // we mimic how the form controls on Kimai preference page looks like
+              const formControl = document.createElement('div');
+              formControl.className = 'mb-3 row';
+              formControl.innerHTML = `
+                  <label class=\"col-form-label col-sm-2\">
+                    \${preferenceLabel} (Read-Only)
+                  </label>
+                  <div class=\"col-sm-10\">
+                    <input readonly=\"readonly\" disabled=\"disabled\" class=\"form-control\" value=\"\${preferenceValue}\">
+                  </div>
+              `;
+
+              formBody.appendChild(formControl);
+            })
+          }
+
+          showVacationInformation();
+          </script>";
+        }
+
         if (null === ($user = $event->getUser())) {
             return;
         }

--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -56,7 +56,7 @@ class UserProfileSubscriber implements EventSubscriberInterface
         );
 
         $event->addPreference(
-            (new UserPreference('yearly-fte-vacation-days', 35))
+            (new UserPreference('yearly-fte-vacation-hours', 168))
                 ->setValue(35)
                 ->setType(NumberType::class)
                 ->setOptions(['attr' => ['disabled' => !$isAdmin]]) // Make readonly if not admin
@@ -94,7 +94,7 @@ class UserProfileSubscriber implements EventSubscriberInterface
 
         // Not accounting for leap years
         $year_length = 365 * 24 * 60 * 60;
-        $vacation_hours_per_second = 24 * $user->getPreferenceValue('yearly-fte-vacation-days') / $year_length;
+        $vacation_hours_per_second = 24 * $user->getPreferenceValue('yearly-fte-vacation-hours') / $year_length;
 
         $earned_hours = $fte_ratio * $seconds_elapsed * $vacation_hours_per_second;
         $total_vacation_hours = $leftover_hours + $earned_hours;

--- a/Widget/SlidingMonthProgressWidget.php
+++ b/Widget/SlidingMonthProgressWidget.php
@@ -86,14 +86,6 @@ final class SlidingMonthProgressWidget extends AbstractWidget
 		$minutes = floor(($seconds_left % 3600) / 60);
 		
 		$formatted_time = sprintf("%02d:%02d h", $hours, $minutes);
-		// print_r([
-		// 	'fte_ratio' => $fte_ratio,
-		// 	'elapsed_weeks' => $elapsed_weeks,
-		// 	'expected_work_hours' => $expected_work_hours,
-		// 	'worked_hours' => $worked_hours,
-		// 	'work_left' => $work_left,
-		// 	'work_left * 60 * 60' => (int) ($work_left * 60 * 60),
-		// ]);
 
 		return $formatted_time;
 	}

--- a/Widget/SlidingMonthProgressWidget.php
+++ b/Widget/SlidingMonthProgressWidget.php
@@ -34,7 +34,7 @@ final class SlidingMonthProgressWidget extends AbstractWidget
 
 	public function getHeight(): int
 	{
-		return WidgetInterface::HEIGHT_FULL/2;
+		return WidgetInterface::HEIGHT_SMALL;
 	}
 
 	public function getOptions(array $options = []): array

--- a/Widget/SlidingMonthProgressWidget.php
+++ b/Widget/SlidingMonthProgressWidget.php
@@ -66,9 +66,9 @@ final class SlidingMonthProgressWidget extends AbstractWidget
 		if ($seconds_elapsed < 0)
 			return null;
 		$endDate = new DateTime();
-		$user = $this->getUser();
 		$endDate->setTimestamp($accounting_end);
-
+		
+		$user = $this->getUser();
 		$fte_ratio = $user->getPreferenceValue('target-weekly-hours', 0) / 40.0;
 
 		$elapsed_weeks = $seconds_elapsed / $week_length;
@@ -77,13 +77,12 @@ final class SlidingMonthProgressWidget extends AbstractWidget
 
 		$worked_hours = $this->repository->getStatistic('duration', $startDate, $endDate, $user) / 60 / 60;
 
-		$work_left = max(0, $expected_work_hours - $worked_hours);
+		$work_hours_left = max(0, $expected_work_hours - $worked_hours);
 
+		$work_seconds_left = (int) ($work_hours_left * 60 * 60);
 
-		$seconds_left = (int) ($work_left * 60 * 60);
-
-		$hours = floor($seconds_left / 3600);
-		$minutes = floor(($seconds_left % 3600) / 60);
+		$hours = floor($work_seconds_left / 3600);
+		$minutes = floor(($work_seconds_left % 3600) / 60);
 		
 		$formatted_time = sprintf("%02d:%02d h", $hours, $minutes);
 

--- a/Widget/VacationWidget.php
+++ b/Widget/VacationWidget.php
@@ -99,18 +99,6 @@ final class VacationWidget extends AbstractWidget
 		$hours = floor($vacation_hours_left);
 		$minutes = ($vacation_hours_left - $hours) * 60;
 		$formatted_vacation_hours = sprintf("%02d:%02d h", $hours, $minutes);
-
-		print_r([
-			'fte_ratio' => $fte_ratio,
-			'leftover_hours' => $leftover_hours,
-			'vacation_hours_per_second' => $vacation_hours_per_second,
-			'earned_hours' => $earned_hours,
-			'expected_work_hours' => $expected_work_hours,
-			'worked_hours' => $worked_hours,
-			'work_left' => $work_left,
-			'vacation_hours_left' => (int) ($vacation_hours_left),
-			'extra_vacation_hours' => $extra_vacation_hours,
-		]);
 		return $formatted_vacation_hours;
 
 	}

--- a/Widget/VacationWidget.php
+++ b/Widget/VacationWidget.php
@@ -30,12 +30,12 @@ final class VacationWidget extends AbstractWidget
 
 	public function getWidth(): int
 	{
-		return WidgetInterface::WIDTH_FULL;
+		return WidgetInterface::WIDTH_SMALL;
 	}
 
 	public function getHeight(): int
 	{
-		return WidgetInterface::HEIGHT_FULL;
+		return WidgetInterface::HEIGHT_SMALL;
 	}
 
 	public function getOptions(array $options = []): array

--- a/Widget/VacationWidget.php
+++ b/Widget/VacationWidget.php
@@ -72,7 +72,7 @@ final class VacationWidget extends AbstractWidget
 		// Leftover vacation hours from previous periods
 		$leftover_hours = $user->getPreferenceValue('start-of-period-vacation-hours', 0);
 
-		// Total seconds in a year
+		// Total seconds in a year, not account for leap years
 		$year_length = 365 * 24 * 60 * 60;
 
 		// Calculate accrued vacation hours per second
@@ -81,8 +81,7 @@ final class VacationWidget extends AbstractWidget
 		// Earned vacation hours based on elapsed time
 		$earned_hours = $seconds_elapsed * $vacation_hours_per_second;
 
-		// Extra 5 days of vacation converted to hours
-		$extra_vacation_hours = 5 * $user->getPreferenceValue('extra-vacation-hours');
+		$extra_vacation_hours = $user->getPreferenceValue('extra-vacation-hours');
 		$total_vacation_hours = $leftover_hours + $earned_hours + $extra_vacation_hours;
 
 		// Expected work hours based on weeks elapsed

--- a/Widget/VacationWidget.php
+++ b/Widget/VacationWidget.php
@@ -53,37 +53,34 @@ final class VacationWidget extends AbstractWidget
 	{
 
 		$options = $this->getOptions($options);
-		// $user = $options['user'];
 		$user = $this->getUser();
 		$accounting_start = strtotime($user->getPreferenceValue('target-weekly-start'));
 		if ($accounting_start === false)
 			return null;
+
 		$startDate = new DateTime();
 		$startDate->setTimestamp($accounting_start);
-
 		$seconds_elapsed = time() - $accounting_start;
 		if ($seconds_elapsed < 0)
 			return null;
 		$endDate = new DateTime();
-		$user = $this->getUser();
 
+		// for 32h per week, this will be 0.8
 		$fte_ratio = $user->getPreferenceValue('target-weekly-hours', 0) / 40.0;
-
 		$leftover_hours = $user->getPreferenceValue('start-of-period-vacation-hours', 0);
 
-		// Not accounting for leap years
-		$year_length = 365 * 24 * 60 * 60;
-		$vacation_hours_per_second = 8 * $user->getPreferenceValue('yearly-fte-vacation-days') / $year_length;
+		// Calculate vacation accrual per second in hours
+		$year_length = 365 * 24 * 60 * 60; // Total seconds in a year
+		$vacation_hours_per_second = ($fte_ratio * $user->getPreferenceValue('yearly-fte-vacation-hours') * 8) / $year_length;
 
-		$earned_hours = $fte_ratio * $seconds_elapsed * $vacation_hours_per_second;
+		// Earned hours based on time elapsed
 
+		$earned_hours = $seconds_elapsed * $vacation_hours_per_second;
 		$total_vacation_hours = $leftover_hours + $earned_hours;
 
 		$week_length = 7 * 24 * 60 * 60;
 		$elapsed_weeks = $seconds_elapsed / $week_length;
-
 		$expected_work_hours = $elapsed_weeks * $fte_ratio * 40;
-
 		$worked_hours = $this->repository->getStatistic('duration', $startDate, $endDate, $user) / 60 / 60;
 
 		$work_left = $expected_work_hours - $total_vacation_hours - $worked_hours;
@@ -99,6 +96,7 @@ final class VacationWidget extends AbstractWidget
 		// 	'vacation_hours_left' => (int) ($vacation_hours_left),
 		// ]);
 
+		// Formatting as hours and minutes
 		$hours = floor($vacation_hours_left);
 		$minutes = ($vacation_hours_left - $hours) * 60;
 		$formatted_vacation_hours = sprintf("%02d:%02d h", $hours, $minutes);
@@ -115,9 +113,9 @@ final class VacationWidget extends AbstractWidget
 		return 'Vacation hours left';
 	}
 	public function getOrder(): int
-    {
-        return 20;
-    }
+	{
+		return 20;
+	}
 
 	public function getTemplateName(): string
 	{

--- a/Widget/VacationWidget.php
+++ b/Widget/VacationWidget.php
@@ -82,7 +82,7 @@ final class VacationWidget extends AbstractWidget
 		$earned_hours = $seconds_elapsed * $vacation_hours_per_second;
 
 		// Extra 5 days of vacation converted to hours
-		$extra_vacation_hours = 5 * $user->getPreferenceValue('extra-vacation');
+		$extra_vacation_hours = 5 * $user->getPreferenceValue('extra-vacation-hours');
 		$total_vacation_hours = $leftover_hours + $earned_hours + $extra_vacation_hours;
 
 		// Expected work hours based on weeks elapsed

--- a/Widget/VacationWidget.php
+++ b/Widget/VacationWidget.php
@@ -76,7 +76,7 @@ final class VacationWidget extends AbstractWidget
 		$year_length = 365 * 24 * 60 * 60;
 
 		// Calculate accrued vacation hours per second
-		$vacation_hours_per_second = ($fte_ratio * $user->getPreferenceValue('yearly-vacation-hours') * 8) / $year_length;
+		$vacation_hours_per_second = $user->getPreferenceValue('yearly-vacation-hours') / $year_length;
 
 		// Earned vacation hours based on elapsed time
 		$earned_hours = $seconds_elapsed * $vacation_hours_per_second;

--- a/Widget/WeekProgressWidget.php
+++ b/Widget/WeekProgressWidget.php
@@ -70,6 +70,7 @@ final class WeekProgressWidget extends AbstractWidget
 			return null;
 		$endDate = new DateTime();
 		$endDate->setTimestamp($accounting_end);
+
 		$user = $this->getUser();
 		$fte_ratio = $user->getPreferenceValue('target-weekly-hours', 0) / 40.0;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,3 +39,5 @@ volumes:
 # Remove containers with their id's  docker rm  $(docker ps -aq)
 
 # Admin user:username: admin mail:admin@example.com pass: 1234!@#$
+#tannaz user: pass:12345678
+#dj as admin: pass:12345678

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,3 @@ volumes:
 
 # Create a new username as an admin /opt/kimai/bin/console kimai:user:create admin admin@example.com ROLE_SUPER_ADMIN
 # Remove containers with their id's  docker rm  $(docker ps -aq)
-
-# Admin user:username: admin mail:admin@example.com pass: 1234!@#$
-#tannaz user: pass:12345678
-#dj as admin: pass:12345678


### PR DESCRIPTION
Hello. I tried so much, but I couldn't find any way to enforce server-side validation on Kimai.
Things I tried:
- Checking Kimai source code and Symfony docs to see if there is any way to write declarative validation, there was some, but required changes in Kimai source code
- Implementing my validation in `PrepareUserEvent`, but no luck there, as at the time that event listener is called, we have no source of truth to check changes against


Instead I tried disabling those fields altogether and instead wrote a piece of small javascript code in `loadUserProfile` that creates 5 inputs with the same labels, but they are not the same inputs, so they are immune to changing HTML in client-side.