### PR TITLE
Fix null reference for not logged in users

### DIFF
--- a/EventSubscriber/ThemeEventSubscriber.php
+++ b/EventSubscriber/ThemeEventSubscriber.php
@@ -30,7 +30,7 @@ final class ThemeEventSubscriber implements EventSubscriberInterface
         if (!$event->getUser())
             return;
 
-        if(!$this->security->isGranted('ROLE_ADMIN')) {
+        if (!$this->security->isGranted('ROLE_ADMIN')) {
             // if user is not admin, we show them an unsubmittable fake input, so they know their vacation information
             $script = "<script>
               async function showVacationInformation() {

--- a/EventSubscriber/ThemeEventSubscriber.php
+++ b/EventSubscriber/ThemeEventSubscriber.php
@@ -27,52 +27,53 @@ final class ThemeEventSubscriber implements EventSubscriberInterface
 
     public function injectJavascript(ThemeEvent $event): void
     {
-    $isAdmin = $this->security->isGranted('ROLE_ADMIN');
+        if (!$event->getUser())
+            return;
 
-        if(!$isAdmin) {
-          // if user is not admin, we show them an unsubmittable fake input, so they know their vacation information
-          $script = "<script>
-          async function showVacationInformation() {
-            if (window.DS_VacationData) {
-              // The `loadUserProfile` is usually called multiple times,
-              // and we need to bail out if this function is executed once.
-              return;
-            }
+        if(!$this->security->isGranted('ROLE_ADMIN')) {
+            // if user is not admin, we show them an unsubmittable fake input, so they know their vacation information
+            $script = "<script>
+              async function showVacationInformation() {
+                if (window.DS_VacationData) {
+                  // The `loadUserProfile` is usually called multiple times,
+                  // and we need to bail out if this function is executed once.
+                  return;
+                }
 
-            // we want to show the inputs to user only on prefs page
-            if (!window.location.href.endsWith('/prefs')) return;
+                // we want to show the inputs to user only on prefs page
+                if (!window.location.href.endsWith('/prefs')) return;
 
-            window.DS_VacationData = {
-                'Target Weekly Hours': '" . $event->getUser()->getPreferenceValue('target-weekly-hours') . "',
-                'Target Weekly Start': '" . date_format(date_create($event->getUser()->getPreferenceValue('target-weekly-start')), "Y-m-d") . "',
-                'Yearly Vacation Hours': '" . $event->getUser()->getPreferenceValue('yearly-vacation-hours') . "',
-                'Start of Period Vacation Hours': '" . $event->getUser()->getPreferenceValue('start-of-period-vacation-hours') . "',
-                'Extra Vacation Hours': '" . $event->getUser()->getPreferenceValue('extra-vacation-hours') . "',
-            };
+                window.DS_VacationData = {
+                    'Target Weekly Hours': '" . $event->getUser()->getPreferenceValue('target-weekly-hours') . "',
+                    'Target Weekly Start': '" . date_format(date_create($event->getUser()->getPreferenceValue('target-weekly-start')), "Y-m-d") . "',
+                    'Yearly Vacation Hours': '" . $event->getUser()->getPreferenceValue('yearly-vacation-hours') . "',
+                    'Start of Period Vacation Hours': '" . $event->getUser()->getPreferenceValue('start-of-period-vacation-hours') . "',
+                    'Extra Vacation Hours': '" . $event->getUser()->getPreferenceValue('extra-vacation-hours') . "',
+                };
 
-            const form = document.querySelector('form');
-            const formBody = form.querySelector('.card-body');
+                const form = document.querySelector('form');
+                const formBody = form.querySelector('.card-body');
 
-            Object.entries(window.DS_VacationData).forEach(([preferenceLabel, preferenceValue]) => {
-              // we mimic how the form controls on Kimai preference page looks like
-              const formControl = document.createElement('div');
-              formControl.className = 'mb-3 row';
-              formControl.innerHTML = `
-                  <label class=\"col-form-label col-sm-2\">
-                    \${preferenceLabel} (Read-Only)
-                  </label>
-                  <div class=\"col-sm-10\">
-                    <input readonly=\"readonly\" disabled=\"disabled\" class=\"form-control\" value=\"\${preferenceValue}\">
-                  </div>
-              `;
+                Object.entries(window.DS_VacationData).forEach(([preferenceLabel, preferenceValue]) => {
+                  // we mimic how the form controls on Kimai preference page looks like
+                  const formControl = document.createElement('div');
+                  formControl.className = 'mb-3 row';
+                  formControl.innerHTML = `
+                      <label class=\"col-form-label col-sm-2\">
+                        \${preferenceLabel} (Read-Only)
+                      </label>
+                      <div class=\"col-sm-10\">
+                        <input readonly=\"readonly\" disabled=\"disabled\" class=\"form-control\" value=\"\${preferenceValue}\">
+                      </div>
+                  `;
 
-              formBody.appendChild(formControl);
-            });
-          }
+                  formBody.appendChild(formControl);
+                });
+              }
 
-          document.addEventListener('DOMContentLoaded', showVacationInformation);
-      </script>";
-      $event->addContent($script);
-    }
+              document.addEventListener('DOMContentLoaded', showVacationInformation);
+              </script>";
+          $event->addContent($script);
+        }
     }
 }

--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -4,10 +4,7 @@ namespace KimaiPlugin\VacationHoursBundle\EventSubscriber;
 
 use App\Entity\UserPreference;
 use App\Event\UserPreferenceEvent;
-use App\Event\PrepareUserEvent;
-use App\Repository\TimesheetRepository;
 use Symfony\Component\Security\Core\Security;
-use DateTime;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -15,20 +12,14 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class UserProfileSubscriber implements EventSubscriberInterface
 {
-    protected $repository;
-    private $security;
-
-    public function __construct(TimesheetRepository $repository, Security $security)
+    public function __construct(private Security $security)
     {
-        $this->repository = $repository;
-        $this->security = $security;
     }
 
     public static function getSubscribedEvents(): array
     {
         return [
             UserPreferenceEvent::class => ['loadUserPreferences', 200],
-            PrepareUserEvent::class => ['loadUserProfile', 300]
         ];
     }
 
@@ -75,45 +66,5 @@ class UserProfileSubscriber implements EventSubscriberInterface
                 ->setType(IntegerType::class)
                 ->setOptions(['label' => 'Extra Vacation Hours' . ($isAdmin ? '' : ' (Read-Only)'), 'attr' => ['readonly' => !$isAdmin]]) // Make readonly if not admin
         );
-    }
-
-    public function loadUserProfile(PrepareUserEvent $event)
-    {
-        if (null === ($user = $event->getUser())) {
-            return;
-        }
-
-        $accounting_start = strtotime($user->getPreferenceValue('target-weekly-start'));
-        if ($accounting_start === false) {
-            return;
-        }
-        $startDate = new DateTime();
-        $startDate->setTimestamp($accounting_start);
-
-        $seconds_elapsed = time() - $accounting_start;
-        if ($seconds_elapsed < 0) {
-            return;
-        }
-        $endDate = new DateTime();
-
-        $fte_ratio = $user->getPreferenceValue('target-weekly-hours', 0) / 40.0;
-        $leftover_hours = $user->getPreferenceValue('start-of-period-vacation-hours', 0);
-
-        // Not accounting for leap years
-        $year_length = 365 * 24 * 60 * 60;
-        $vacation_hours_per_second = $user->getPreferenceValue('yearly-vacation-hours') / $year_length;
-
-        $extra_vacation_hours = $user->getPreferenceValue('extra-vacation-hours');
-
-        $earned_hours = $seconds_elapsed * $vacation_hours_per_second;
-        $total_vacation_hours = $leftover_hours + $earned_hours + $extra_vacation_hours;
-
-        $week_length = 7 * 24 * 60 * 60;
-        $elapsed_weeks = $seconds_elapsed / $week_length;
-
-        $expected_work_hours = $elapsed_weeks * $fte_ratio * 40;
-        $worked_hours = $this->repository->getStatistic('duration', $startDate, $endDate, $user) / 60 / 60;
-
-        $work_left = $expected_work_hours - $total_vacation_hours - $worked_hours;
     }
 }

--- a/Library/VacationHoursCalculator.php
+++ b/Library/VacationHoursCalculator.php
@@ -51,4 +51,51 @@ class VacationHoursCalculator
 
 		return $vacation_hours_left;
 	}
+
+	public static function calculateHoursOld(User $user, TimeSheetRepository $repository)
+	{
+		$accounting_start = strtotime($user->getPreferenceValue('target-weekly-start'));
+		if ($accounting_start === false) return;
+		$startDate = new DateTime();
+		$startDate->setTimestamp($accounting_start);
+
+		$seconds_elapsed = time() - $accounting_start;
+		if ($seconds_elapsed < 0) return;
+		$endDate = new DateTime();
+
+		$fte_ratio = $user->getPreferenceValue('target-weekly-hours', 0) / 40.0;
+
+		$leftover_hours = $user->getPreferenceValue('start-of-period-vacation-hours', 0);
+
+		// Not accounting for leap years
+		$year_length = 365 * 24 * 60 * 60;
+		$vacation_hours_per_second = 8 * $user->getPreferenceValue('yearly-fte-vacation-days') / $year_length;
+
+		$earned_hours = $fte_ratio * $seconds_elapsed * $vacation_hours_per_second;
+
+		$total_vacation_hours = $leftover_hours + $earned_hours;
+
+		$week_length = 7 * 24 * 60 * 60;
+		$elapsed_weeks = $seconds_elapsed / $week_length;
+
+		$expected_work_hours = $elapsed_weeks * $fte_ratio * 40;
+
+		$worked_hours = $repository->getStatistic('duration', $startDate, $endDate, $user) / 60 / 60;
+
+		$work_left = $expected_work_hours - $total_vacation_hours - $worked_hours;
+		$vacation_hours_left = max(0, -$work_left);
+
+		# Instead of seconds, we return the time in hours, so that each calculation returns a value in the same unit
+		#return (int)($vacation_hours_left * 60 * 60);
+		return $vacation_hours_left;
+	}
+
+	public static function formatHours(float $time)
+	{
+		// Formatting as hours and minutes
+		$hours = floor($time);
+		$minutes = ($time - $hours) * 60;
+		$formatted_vacation_hours = sprintf("%02d:%02d h", $hours, $minutes);
+		return $formatted_vacation_hours;
+	}
 }

--- a/Library/VacationHoursCalculator.php
+++ b/Library/VacationHoursCalculator.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace KimaiPlugin\VacationHoursBundle\Library;
+
+use App\Entity\User;
+use App\Repository\TimeSheetRepository;
+use DateTime;
+
+class VacationHoursCalculator
+{
+	public static function calculateHours(User $user, TimeSheetRepository $repository)
+	{
+		$accounting_start = strtotime($user->getPreferenceValue('target-weekly-start'));
+		if ($accounting_start === false)
+			return null;
+
+		$startDate = new DateTime();
+		$startDate->setTimestamp($accounting_start);
+		$seconds_elapsed = time() - $accounting_start;
+		if ($seconds_elapsed < 0)
+			return null;
+		$endDate = new DateTime();
+
+		// for 32h per week, this will be 0.8
+		$fte_ratio = $user->getPreferenceValue('target-weekly-hours', 0) / 40.0;
+
+		// Leftover vacation hours from previous periods
+		$leftover_hours = $user->getPreferenceValue('start-of-period-vacation-hours', 0);
+
+		// Total seconds in a year, not account for leap years
+		$year_length = 365 * 24 * 60 * 60;
+
+		// Calculate accrued vacation hours per second
+		$vacation_hours_per_second = $user->getPreferenceValue('yearly-vacation-hours') / $year_length;
+
+		// Earned vacation hours based on elapsed time
+		$earned_hours = $seconds_elapsed * $vacation_hours_per_second;
+
+		$extra_vacation_hours = $user->getPreferenceValue('extra-vacation-hours');
+		$total_vacation_hours = $leftover_hours + $earned_hours + $extra_vacation_hours;
+
+		// Expected work hours based on weeks elapsed
+		$week_length = 7 * 24 * 60 * 60;
+		$elapsed_weeks = $seconds_elapsed / $week_length;
+		$expected_work_hours = $elapsed_weeks * $fte_ratio * 40;
+		$worked_hours = $repository->getStatistic('duration', $startDate, $endDate, $user) / 60 / 60;
+
+		// Remaining vacation hours calculation
+		$work_left = $expected_work_hours - $total_vacation_hours - $worked_hours;
+		$vacation_hours_left = max(0, -$work_left);
+
+		return $vacation_hours_left;
+	}
+}

--- a/Widget/VacationWidget.php
+++ b/Widget/VacationWidget.php
@@ -2,30 +2,16 @@
 
 namespace KimaiPlugin\VacationHoursBundle\Widget;
 
-use App\Repository\TimesheetRepository;
 use App\Widget\Type\AbstractWidget;
-use DateTime;
-use DateInterval;
-// use App\Security\CurrentUser;
 use App\Widget\Type\SimpleWidget;
 use App\Widget\WidgetInterface;
+use App\Repository\TimesheetRepository;
+use KimaiPlugin\VacationHoursBundle\Library\VacationHoursCalculator;
 
 final class VacationWidget extends AbstractWidget
 {
 	public function __construct(private TimesheetRepository $repository)
 	{
-		// $user = $this->getUser();
-		// $this->repository = $repository;
-
-
-		// $this->setId('VacationWidget');
-		// $this->setTitle('vacation hours left');
-		// $this->getOptions([
-		// 	'user' => $user->getUser(),
-		// 	'id' => '',
-		// 'icon' => 'time',
-		// 	'dataType' => 'duration',
-		// ]);
 	}
 
 	public function getWidth(): int
@@ -51,50 +37,13 @@ final class VacationWidget extends AbstractWidget
 
 	public function getData(array $options = []): mixed
 	{
-
-		$options = $this->getOptions($options);
 		$user = $this->getUser();
 
-		$accounting_start = strtotime($user->getPreferenceValue('target-weekly-start'));
-		if ($accounting_start === false)
+		$vacation_hours_left = VacationHoursCalculator::calculatehours($user, $this->repository);
+
+		if (is_null($vacation_hours_left))
 			return null;
 
-		$startDate = new DateTime();
-		$startDate->setTimestamp($accounting_start);
-		$seconds_elapsed = time() - $accounting_start;
-		if ($seconds_elapsed < 0)
-			return null;
-		$endDate = new DateTime();
-
-		// for 32h per week, this will be 0.8
-		$fte_ratio = $user->getPreferenceValue('target-weekly-hours', 0) / 40.0;
-
-		// Leftover vacation hours from previous periods
-		$leftover_hours = $user->getPreferenceValue('start-of-period-vacation-hours', 0);
-
-		// Total seconds in a year, not account for leap years
-		$year_length = 365 * 24 * 60 * 60;
-
-		// Calculate accrued vacation hours per second
-		$vacation_hours_per_second = $user->getPreferenceValue('yearly-vacation-hours') / $year_length;
-
-		// Earned vacation hours based on elapsed time
-		$earned_hours = $seconds_elapsed * $vacation_hours_per_second;
-
-		$extra_vacation_hours = $user->getPreferenceValue('extra-vacation-hours');
-		$total_vacation_hours = $leftover_hours + $earned_hours + $extra_vacation_hours;
-
-		// Expected work hours based on weeks elapsed
-		$week_length = 7 * 24 * 60 * 60;
-		$elapsed_weeks = $seconds_elapsed / $week_length;
-		$expected_work_hours = $elapsed_weeks * $fte_ratio * 40;
-		$worked_hours = $this->repository->getStatistic('duration', $startDate, $endDate, $user) / 60 / 60;
-
-		// Remaining vacation hours calculation
-		$work_left = $expected_work_hours - $total_vacation_hours - $worked_hours;
-		$vacation_hours_left = max(0, -$work_left);
-
-		// Formatting as hours and minutes
 		$hours = floor($vacation_hours_left);
 		$minutes = ($vacation_hours_left - $hours) * 60;
 		$formatted_vacation_hours = sprintf("%02d:%02d h", $hours, $minutes);


### PR DESCRIPTION
Script was inject on the login page, and was trying to retrieve user preferences from a non-existing (null) user. Now, if there is no user, the script is not injected. This should prevent the error, and some minor information leaking (such as the fact that this plugin is present, because of the presence of the script)