### PR TITLE
fixed preferences, typos and icons

### DIFF
--- a/EventSubscriber/UserProfileSubscriber.php
+++ b/EventSubscriber/UserProfileSubscriber.php
@@ -36,35 +36,35 @@ class UserProfileSubscriber implements EventSubscriberInterface
 
         $event->addPreference(
             (new UserPreference('target-weekly-hours', 32))
-                ->setEnabled($isAdmin)
+                ->setEnabled(!$isAdmin)
                 ->setType(IntegerType::class)
                 ->setOptions(['label' => 'Target Weekly Hours' . ($isAdmin ? '' : ' (Read-Only)'), 'attr' => ['readonly' => !$isAdmin]]) // Make readonly if not admin
         );
 
         $event->addPreference(
             (new UserPreference('target-weekly-start', '1970-01-30'))
-                ->setEnabled($isAdmin)
+                ->setEnabled(!$isAdmin)
                 ->setType(TextType::class)
                 ->setOptions(['label'    => 'Target Weekly Start Date' . ($isAdmin ? '' : ' (Read-Only)'), 'attr' => ['readonly' => !$isAdmin]]) // Make readonly if not admin
         );
 
         $event->addPreference(
             (new UserPreference('yearly-vacation-days', 16))
-                ->setEnabled($isAdmin)
+                ->setEnabled(!$isAdmin)
                 ->setType(NumberType::class)
                 ->setOptions(['label' => 'Yearly Vacation Days' . ($isAdmin ? '' : ' (Read-Only)'), 'attr' => ['readonly' => !$isAdmin]]) // Make readonly if not admin
         );
 
         $event->addPreference(
             (new UserPreference('start-of-period-vacation-hours', 0))
-                ->setEnabled($isAdmin)
+                ->setEnabled(!$isAdmin)
                 ->setType(NumberType::class)
                 ->setOptions(['label' => 'Start of Period Vacation Hours' . ($isAdmin ? '' : ' (Read-Only)'), 'attr' => ['readonly' => !$isAdmin]]) // Make readonly if not admin
         );
 
         $event->addPreference(
             (new UserPreference('extra-vacation-days', 0))
-                ->setEnabled($isAdmin)
+                ->setEnabled(!$isAdmin)
                 ->setType(IntegerType::class)
                 ->setOptions(['label' => 'Extra Vacation Days' . ($isAdmin ? '' : ' (Read-Only)'), 'attr' => ['readonly' => !$isAdmin]]) // Make readonly if not admin
 	);

--- a/Widget/SlidingMonthProgressWidget.php
+++ b/Widget/SlidingMonthProgressWidget.php
@@ -29,7 +29,7 @@ final class SlidingMonthProgressWidget extends AbstractWidget
 	{
 		$options = parent::getOptions($options);
 
-		$options['icon'] = 'fa-regular fa-business-time';
+		$options['icon'] = 'fa-solid fa-business-time';
 		if (empty($options['id'])) {
 			$options['id'] = 'SlidingMonthProgressWidget';
 		}

--- a/Widget/WeekProgressWidget.php
+++ b/Widget/WeekProgressWidget.php
@@ -30,7 +30,7 @@ final class WeekProgressWidget extends AbstractWidget
 	{
 		$options = parent::getOptions($options);
 
-		$options['icon'] = 'fa-regular fa-business-time';
+		$options['icon'] = 'fa-solid fa-business-time';
 		if (empty($options['id'])) {
 			$options['id'] = 'WeekProgressWidget';
 


### PR DESCRIPTION
Each user should see the current settings for vacation hours (read only)